### PR TITLE
Don't specify version when using version-file input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
             exit 1
           fi
 
-          if [ -z "${VERSION}" ]; then
+          if [ -n "${VERSION}" ]; then
             echo "::error version is non-empty"
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,8 +156,8 @@ jobs:
             exit 1
           fi
 
-          if [ "${VERSION}" != "v0.13.4" ]; then
-            echo "::error version != 'v0.13.4'"
+          if [ -z "${VERSION}" ]; then
+            echo "::error version is non-empty"
             exit 1
           fi
         env:

--- a/README.md
+++ b/README.md
@@ -79,4 +79,6 @@ solution, e.g. [Dependabot] or [Renovate].
 | `version` | String | The installed version.                           |
 
 If the `version` input was latest, it will be the actual version that was
-installed. Otherwise it will be identical to the `version` input.
+installed. Otherwise it will be identical to the `version` input. This also
+includes when `version-file` is used in which case the `version` output will be
+unset.

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
 outputs:
   cached:
     description: 'Whether the binary was installed from the cache.'
-    value: ${{ steps.cache.outputs.cache-hit }}
+    value: ${{ steps.cache.outputs.cache-hit == 'true' }}
   name:
     description: 'The name of the installed binary.'
     value: ${{ steps.gather.outputs.name }}

--- a/action.yml
+++ b/action.yml
@@ -38,11 +38,10 @@ runs:
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       with:
         script: |
-          const fs = require('fs');
           const path = require('path');
 
           const script = require(path.join(process.env.GITHUB_ACTION_PATH, 'gather.js'));
-          await script({ core, exec, fs, path });
+          await script({ core, exec, glob, path });
       env:
         package: ${{ inputs.package }}
         version: ${{ inputs.version }}

--- a/action.yml
+++ b/action.yml
@@ -64,5 +64,6 @@ runs:
           const script = require(path.join(process.env.GITHUB_ACTION_PATH, 'install.js'));
           await script({ exec });
       env:
+        dir: ${{ steps.gather.outputs.dir }}
         package: ${{ inputs.package }}
         version: ${{ steps.gather.outputs.version }}

--- a/gather.js
+++ b/gather.js
@@ -1,13 +1,12 @@
 /*global module, process*/
 
 /**
- * Gathers 3 pieces of information:
+ * Gathers various pieces of information:
  *
  * - The binary name from the package path.
  * - The version, converting 'latest' to an actual version to support cache invalidation.
- * - The cache key based on the name, version and runner.
- *
- * TODO: rewrite
+ * - The cache key based on the name, runner and a representation of the version.
+ * - The directory to run the 'go install' command from.
  */
 module.exports = async ({ core, exec, glob, path }) => {
   const pkg = process.env.package;
@@ -71,6 +70,7 @@ async function handleVersionFile({ core, glob, name, path, versionFile }) {
     return;
   }
 
+  // use a hash so that updating any dependency update invalidates the cache
   const hash = await glob.hashFiles(versionFile);
 
   core.setOutput("dir", path.dirname(versionFile));

--- a/gather.js
+++ b/gather.js
@@ -6,8 +6,10 @@
  * - The binary name from the package path.
  * - The version, converting 'latest' to an actual version to support cache invalidation.
  * - The cache key based on the name, version and runner.
+ *
+ * TODO: rewrite
  */
-module.exports = async ({ core, exec, fs, path }) => {
+module.exports = async ({ core, exec, glob, path }) => {
   const pkg = process.env.package;
 
   const name = getBinName(pkg);
@@ -15,19 +17,13 @@ module.exports = async ({ core, exec, fs, path }) => {
 
   const version = process.env.version;
   if (version != "latest") {
-    core.setOutput("version", version);
-    core.setOutput("key", makeKey({ name, version }));
-
+    handleVersion({ core, name, version });
     return;
   }
 
   const versionFile = process.env.version_file;
-  let versions;
-
-  try {
-    versions = await parseVersionFile({ core, exec, fs, path, versionFile });
-  } catch (e) {
-    core.setFailed(e);
+  if (versionFile != "") {
+    await parseVersionFile({ core, glob, path, versionFile });
     return;
   }
 
@@ -59,7 +55,7 @@ module.exports = async ({ core, exec, fs, path }) => {
       }
 
       core.setOutput("version", version);
-      core.setOutput("key", makeKey({ name, version }));
+      core.setOutput("key", makeKey(name, version));
 
       return;
     }
@@ -69,46 +65,41 @@ module.exports = async ({ core, exec, fs, path }) => {
 };
 
 /**
- * parseVersionFile converts a go.mod file to a map of Go modules and versions.
+ * Set outputs for when a specific version has been requested.
  */
-async function parseVersionFile({ core, exec, fs, path, versionFile }) {
-  if (versionFile == "") {
-    return new Map();
-  }
+function handleVersion({ core, name, version }) {
+  core.setOutput("version", version);
+  core.setOutput("key", makeKey(name, version));
+}
 
+/**
+ * Set outputs for when a
+ */
+async function handleVersionFile({ core, glob, path, versionFile }) {
   if (path.basename(versionFile) != "go.mod") {
-    throw new Error(`version-file is not a go.mod file: ${versionFile}`);
+    core.setFailed(`version-file is not a go.mod file: ${versionFile}`);
+    return
   }
 
-  if (!fs.existsSync(versionFile)) {
-    throw new Error(`version-file does not exist: ${versionFile}`);
-  }
+  core.setOutput("dir", path.dirname(versionFile));
 
-  const result = await exec.getExecOutput(
-    "go",
-    ["list", "-mod=readonly", "-m", "-json", "all"],
-    { cwd: path.dirname(versionFile) },
-  );
-  const data = JSON.parse(
-    "[" + result.stdout.replaceAll("}\n{", "},\n{") + "]",
-  );
-
-  return new Map(data.map((d) => [d.Path, d.Version]));
+  const hash = await glob.hashFiles(versionFile);
+  core.setOutput("key", makeKey(name, hash));
 }
 
 /**
  * Build the key to use for cache lookups.
  *
  * Ideally, this would use core instead of process.env, but that requires @actions/core v1.11.0.
- * actions/github-script@v7.0.1 provides @actions/core v1.10.1, which does provide this info.
+ * actions/github-script@v7.0.1 provides @actions/core v1.10.1, which does not provide this info.
  */
-function makeKey({ name, version }) {
+function makeKey(name, suffix) {
   return [
     "go-installer",
     process.env.RUNNER_OS,
     process.env.RUNNER_ARCH,
     name,
-    version,
+    suffix,
   ].join("-");
 }
 

--- a/gather.js
+++ b/gather.js
@@ -23,7 +23,7 @@ module.exports = async ({ core, exec, glob, path }) => {
 
   const versionFile = process.env.version_file;
   if (versionFile != "") {
-    await parseVersionFile({ core, glob, path, versionFile });
+    await handleVersionFile({ core, glob, name, path, versionFile });
     return;
   }
 
@@ -65,10 +65,10 @@ function handleVersion({ core, name, version }) {
 /**
  * Set outputs for when a version file (go.mod) is used.
  */
-async function handleVersionFile({ core, glob, path, versionFile }) {
+async function handleVersionFile({ core, glob, name, path, versionFile }) {
   if (path.basename(versionFile) != "go.mod") {
     core.setFailed(`version-file is not a go.mod file: ${versionFile}`);
-    return
+    return;
   }
 
   const hash = await glob.hashFiles(versionFile);

--- a/gather.js
+++ b/gather.js
@@ -42,17 +42,7 @@ module.exports = async ({ core, exec, glob, path }) => {
         continue;
       }
 
-      if (versionFile != "" && !versions.has(mod)) {
-        core.setFailed(
-          `version-file ${versionFile} is missing package: ${mod}`,
-        );
-        return;
-      }
-
       let version = data.Versions[data.Versions.length - 1];
-      if (versions.has(mod)) {
-        version = versions.get(mod);
-      }
 
       core.setOutput("version", version);
       core.setOutput("key", makeKey(name, version));
@@ -73,7 +63,7 @@ function handleVersion({ core, name, version }) {
 }
 
 /**
- * Set outputs for when a
+ * Set outputs for when a version file (go.mod) is used.
  */
 async function handleVersionFile({ core, glob, path, versionFile }) {
   if (path.basename(versionFile) != "go.mod") {
@@ -81,9 +71,9 @@ async function handleVersionFile({ core, glob, path, versionFile }) {
     return
   }
 
-  core.setOutput("dir", path.dirname(versionFile));
-
   const hash = await glob.hashFiles(versionFile);
+
+  core.setOutput("dir", path.dirname(versionFile));
   core.setOutput("key", makeKey(name, hash));
 }
 

--- a/install.js
+++ b/install.js
@@ -1,11 +1,18 @@
 /*global module, process*/
 
 /**
- * Installs a Go binary at the selected version.
+ * Installs a Go binary at an optional version.
+ *
+ * If the version is unset, it is assumed that the version is
  */
-module.exports = async ({ exec }) => {
+module.exports = async ({ dir, exec }) => {
   const pkg = process.env.package;
   const version = process.env.version;
 
-  await exec.exec("go", ["install", `${pkg}@${version}`]);
+  let path = pkg;
+  if (version != "") {
+    path = `${pkg}@${version}`;
+  }
+
+  await exec.exec("go", ["install", path], { cwd: dir });
 };

--- a/install.js
+++ b/install.js
@@ -3,7 +3,7 @@
 /**
  * Installs a Go binary at an optional version.
  *
- * If the version is unset, it is assumed that the version is
+ * The version is only expected to be unset when a go.mod file is used.
  */
 module.exports = async ({ dir, exec }) => {
   const pkg = process.env.package;

--- a/install.js
+++ b/install.js
@@ -5,7 +5,8 @@
  *
  * The version is only expected to be unset when a go.mod file is used.
  */
-module.exports = async ({ dir, exec }) => {
+module.exports = async ({ exec }) => {
+  const dir = process.env.dir;
   const pkg = process.env.package;
   const version = process.env.version;
 


### PR DESCRIPTION
When using the `version-file` input, the version of the package to be installed is derived from a `go.mod` file. Currently, the version is taken from said file and then installed as normal.

However, using the `go.mod` file also means the transitive dependencies are expected to come from the same file. When specifying a specific version, the transitive dependencies come from the package's `go.mod` file which may be older than the local `go.mod` file. This can cause subtle changes, particularly when improvements have been made to AST representations.

To fix, the version is dropped from the final `go install` command, and support for executing from a different directory is added.

Fixes #8.